### PR TITLE
DSCI-2663: Update actions-python to include new package version before release

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -45,6 +45,11 @@ runs:
       if: inputs.checkout-repo
       with:
         fetch-depth: 0
+        persist-credentials: false
+    - name: Authorize
+      uses: open-turo/action-git-auth@v2
+      with:
+        github-personal-access-token: ${{ inputs.github-token }}
     - name: Set node.js version
       if: hashFiles('.node-version') == ''
       shell: bash
@@ -59,10 +64,6 @@ runs:
       run: python -m pip install --upgrade setuptools wheel twine
     - name: Install poetry
       uses: open-turo/actions-python/poetry-install@v1
-    - name: Authorize
-      uses: open-turo/action-git-auth@v2
-      with:
-        github-personal-access-token: ${{ inputs.github-token }}
     - name: Version
       id: version
       uses: cycjimmy/semantic-release-action@v3


### PR DESCRIPTION

**Description**

To match the package version with github semantic release, we’d want to run a package version update with poetry as part of the release workflow in actions-python.

Fixes [#DSCI-2663](https://team-turo.atlassian.net//browse/DSCI-2663)

**Changes**

* fix(release): do not persist credentials when checking out

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
