### PR TITLE
DSCI-2674: Cut out double release run in python-ml-common

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -93,7 +93,7 @@ runs:
         # Commit the bumped project version with a non-semver chore: commit message
         git add pyproject.toml
         git --no-pager diff --staged
-        git commit -m "chore: release ${{ steps.version.outputs.new_release_version }}"
+        git commit -m "chore: release ${{ steps.version.outputs.new_release_version }} [skip actions]"
 
         # Push the changes to the current (should be main) branch, if this is not a dry-run
         # TODO: This might not be super safe, we should consider that this could


### PR DESCRIPTION

**Description**



Fixes [#DSCI-2674](https://team-turo.atlassian.net//browse/DSCI-2674)

**Changes**

* feat(release): skipping actions when bumping package version

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
