### PR TITLE
DSCI-2674: Cut out double release run in python-ml-common

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -93,10 +93,7 @@ runs:
         # Commit the bumped project version with a non-semver chore: commit message
         git add pyproject.toml
         git --no-pager diff --staged
-        git commit --author="${{ inputs.git-user-name }} <${{ inputs.git-user-email }}>" -m "chore: release ${{ steps.version.outputs.new_release_version }}
-
-
-        skip-checks: true"
+        git commit --author="${{ inputs.git-user-name }} <${{ inputs.git-user-email }}>" -m "chore: release ${{ steps.version.outputs.new_release_version }}" -m "[skip actions]"
 
         # Push the changes to the current (should be main) branch, if this is not a dry-run
         # TODO: This might not be super safe, we should consider that this could


### PR DESCRIPTION

**Description**

[https://github.com/turo/python-ml-common/actions/runs/3709478868](https://github.com/turo/python-ml-common/actions/runs/3709478868) and [https://github.com/turo/python-ml-common/actions/runs/3709502291](https://github.com/turo/python-ml-common/actions/runs/3709502291) are 2 releases that should be 1. In fact the second release is just done because of the chore commit to main.

[https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs "smart-link") we’re using {{skip-checks: true}}in our commit message after two empty lines to get the expected behavior of skipping github actions when commiting a “chore” to main

Fixes [#DSCI-2674](https://team-turo.atlassian.net//browse/DSCI-2674)

**Changes**

* fix(release): change commit syntax

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
