### PR TITLE
fix: do not need to explicitly test for true

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -17,7 +17,7 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v3
-      if: inputs.checkout-repo == 'true'
+      if: inputs.checkout-repo
       with:
         fetch-depth: 0
     - name: Setup tools

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -21,7 +21,7 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v3
-      if: inputs.checkout-repo == 'true'
+      if: inputs.checkout-repo
     - name: Setup tools
       uses: open-turo/action-setup-tools@v1
     # First we attempt to run a pip-based workflow if there is no poetry.lock


### PR DESCRIPTION
`if: inputs.val == 'true'` is the same as `if: inputs.val` so lets use the simpler form throughout all of `open-turo` repos.