### PR TITLE
DSCI-2895: Update actions-python to get version in dry-run mode

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -33,7 +33,7 @@ outputs:
     value: ${{ steps.release.outputs.new_release_published }}
   new-release-version:
     description: Version of the new release
-    value: ${{ steps.release.outputs.new_release_version }}
+    value: ${{ steps.release.outputs.new_release_version ||  steps.version.outputs.new_release_version }}
   new-release-major-version:
     description: Major version of the new release
     value: ${{ steps.release.outputs.new_release_major_version }}


### PR DESCRIPTION

**Description**

In dry-run-mode, actions-python will not output anything when ran from a branch because it is not the main branch. We want to update this behavior to be able to get the new-release-version in dry-run mode to get the version to appear

Fixes [#DSCI-2895](https://team-turo.atlassian.net//browse/DSCI-2895)

**Changes**

* fix: get version for dry run not on main

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
