### PR TITLE
fix(release): default extra-plugins to open-turo/semantic-release-config

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -28,12 +28,12 @@ If you are using this action for protected branches, replace `GITHUB_TOKEN` with
 
 ## Inputs
 
-| parameter     | description                                                                                                           | required | default |
-| ------------- | --------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| checkout-repo | Perform checkout as first step of action                                                                              | `false`  | true    |
-| dry-run       | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file | `false`  | `false` |
-| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.     | `false`  |         |
-| github-token  | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
+| parameter     | description                                                                                                                                                               | required | default                                   |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------- |
+| checkout-repo | Perform checkout as first step of action                                                                                                                                  | `false`  | true                                      |
+| dry-run       | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file                                                     | `false`  | `false`                                   |
+| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer. Defaults to install @open-turo/semantic-release-config. | `false`  | @open-turo/semantic-release-config@^1.4.0 |
+| github-token  | GitHub token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'                                                     | `true`   |                                           |
 
 ## Outputs
 

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -18,7 +18,9 @@ inputs:
     default: "false"
   extra-plugins:
     required: false
-    description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.
+    description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
+    default: |
+      @open-turo/semantic-release-config@^1.4.0
   git-user-name:
     required: false
     description: User name to associate with release version bump commit.


### PR DESCRIPTION
This updates the extra-plugins to default to `@open-turo/semantic-release-config@^1.4.0`.  This will allow us to stop needing to configure it everywhere.