### PR TITLE
DSCI-3297: actions-python

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -11,10 +11,15 @@ inputs:
   github-token:
     required: true
     description: GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'
-    default: ${{ github.token }}
+    default: ""
 runs:
   using: composite
   steps:
+    - name: Authorize
+      uses: open-turo/action-git-auth@v2
+      if: inputs.github-token != ''
+      with:
+        github-personal-access-token: ${{ inputs.github-token }}
     - name: Checkout
       uses: actions/checkout@v3
       if: inputs.checkout-repo

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -8,7 +8,7 @@ inputs:
   github-token:
     required: true
     description: GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'
-    default: ${{ github.token }}
+    default: ""
   pypi-token:
     required: false
     description: PyPI token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.PYPI_TOKEN'
@@ -19,6 +19,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Authorize
+      uses: open-turo/action-git-auth@v2
+      if: inputs.github-token != ''
+      with:
+        github-personal-access-token: ${{ inputs.github-token }}
     - name: Checkout
       uses: actions/checkout@v3
       if: inputs.checkout-repo


### PR DESCRIPTION

**Description**
Add auth to lint and test actions in case a github-token is provided.


Fixes [#DSCI-3297](https://team-turo.atlassian.net//browse/DSCI-3297)

**Changes**

* feat(lint): add auth if github-token is passed
* feat(test): add auth if github-token is passed

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
