### PR TITLE
DSCI-3589: Fix python-version mismatch for action-pre-commit / action-python

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -37,4 +37,4 @@ runs:
       shell: bash
       run: pip install -e .
     - name: Pre-commit
-      uses: open-turo/action-pre-commit@v1
+      uses: open-turo/action-pre-commit@f/dsci-3589_fix_python-version_mismatch_for_action-pre-commit_-_action-python


### PR DESCRIPTION

**Description**

open-turo/actions-python/lint uses open-turo/action-pre-commit. In the current setup action-pre-commit sets a python version (3.10.4) that is different than the one that gets used in the action.

We want to update action-pre-commit to be compatible with actions-python and properly set up python versions.

Fixes [#DSCI-3589](https://team-turo.atlassian.net//browse/DSCI-3589)

**Changes**

* fix: wip

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
