### PR TITLE
fix(poetry): do not try to install root project as a package by default

### DIFF
--- a/lib/poetry-install.sh
+++ b/lib/poetry-install.sh
@@ -28,5 +28,5 @@ poetry config --list
 if [[ -n "$SKIP_POETRY_INSTALL" ]]; then
     echo "Skipping poetry install"
 else
-    poetry install
+    poetry install --no-root --with test
 fi


### PR DESCRIPTION
Poetry tries to install root project as a package by default, this generates a warning for projects that aren't meant to be packages