### PR TITLE
Add back commitlint to action

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -23,11 +23,5 @@ runs:
       if: inputs.checkout-repo == 'true'
       with:
         fetch-depth: 0
-    - name: Setup python
-      uses: actions/setup-python@v5
-    - name: Install pre-commit
-      run: pip install pre-commit
-      shell: bash
     - name: Run pre-commit
-      run: pre-commit run --show-diff-on-failure --color=always --all-files
-      shell: bash
+      uses: open-turo/action-pre-commit@v3


### PR DESCRIPTION
pre-commit does not run on commit trigger here - and commitlint might not be checked/enforced. So adding back `open-turo/action-pre-commit/commitlint`

Also shifting to only installing pre-commit if it cannot be found