### PR TITLE
Remove unnecessary auth step in release

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -36,10 +36,7 @@ runs:
       if: inputs.checkout-repo == 'true'
       with:
         fetch-depth: 0
-    - name: Authorize
-      uses: open-turo/action-git-auth@v2
-      with:
-        github-personal-access-token: ${{ inputs.github-token }}
+        token: ${{ inputs.github-token }}
     - uses: open-turo/actions-release/semantic-release@v4
       id: release
       with:


### PR DESCRIPTION
We don't need authorization for the default release since we don't install any private packages for it. 

If we need it in the future we could add it as an optional step.