### PR TITLE
feat: add caching for poetry venv to python setup

### DIFF
--- a/install-poetry-dependencies/action.yaml
+++ b/install-poetry-dependencies/action.yaml
@@ -1,0 +1,84 @@
+name: Install Dependencies
+description: GitHub Action that installs dependencies in a Python based repository
+inputs:
+  github-token:
+    required: true
+    description: GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'
+    default: ${{ github.token }}
+  s3-bucket-name:
+    required: false
+    description: S3 bucket name to cache node_modules to speed up dependency installation.
+  s3-bucket-region:
+    required: false
+    description: S3 bucket region to cache node_modules to speed up dependency installation.
+outputs:
+  cache-hit:
+    description: Whether the cache was hit when installing dependencies
+    value: ${{ steps.read_cache.outputs.cache-hit }}
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      if: inputs.checkout-repo == 'true'
+      with:
+        fetch-depth: 1
+    - name: Setup tools
+      uses: open-turo/action-setup-tools@v2
+    - name: Check for poetry.lock
+      id: check_poetry_lock
+      uses: andstor/file-existence-action@v3
+      with:
+        files: poetry.lock
+    - name: Check Cache
+      id: check_cache
+      shell: bash
+      run: |
+        if [[ "${{ inputs.s3-bucket-name }}" != '' && "${{ steps.check_poetry_lock.outputs.files_exists }}" == 'true' ]]; then
+          RESULT="true"
+        else
+          RESULT="false"
+        fi
+        echo "::set-output name=result::$RESULT"
+    - name: Extract contents hash from poetry.lock
+      id: lockfile_hash
+      if: step.check_cache.outputs.result == 'true'
+      shell: bash
+      run: |
+        HASH=$(cat poetry.lock | grep "content-hash" | head -1 | awk '{print $3}' | tr -d '"')
+        echo "Poetry Content Hash: $HASH"
+        echo "::set-output name=contents_hash::$HASH"
+    - name: setup poetry venv cache
+      shell: bash
+      run: |
+        poetry config virtualenvs.in-project true
+    - name: Load cached poetry venv if available
+      if: step.check_cache.outputs.result == 'true'
+      uses: tespkg/actions-cache@v1
+      id: read_cache
+      with:
+        bucket: ${{ inputs.s3-bucket-name }}
+        use-fallback: false
+        path: venv
+        key: ${{ env.cache-name }}-${{ steps.lockfile_hash.outputs.contents_hash }}
+        restore-keys: ${{ env.cache-name }}-
+      env:
+        AWS_REGION: ${{ inputs.s3-bucket-region }}
+        cache-name: ${{ github.event.repository.name }}/cache-poetry-venv
+    - name: Install poetry dependencies
+      if: sucess()
+      shell: bash
+      run: poetry install
+    - name: Cache poetry venv
+      if: inputs.s3-bucket-name != '' &&  steps.read_cache.outputs.cache-hit != 'true'
+      uses: tespkg/actions-cache@v1
+      id: write_cache
+      with:
+        bucket: ${{ inputs.s3-bucket-name }}
+        use-fallback: false
+        path: venv
+        key: ${{ env.cache-name }}-${{ steps.lockfile_hash.outputs.hash }}
+        restore-keys: ${{ env.cache-name }}-
+      env:
+        AWS_REGION: ${{ inputs.s3-bucket-region }}
+        cache-name: ${{ github.event.repository.name }}/cache-poetry-venv

--- a/poetry-install/action.yaml
+++ b/poetry-install/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Setup tools
-      uses: open-turo/action-setup-tools@v1
+      uses: open-turo/action-setup-tools@v2
     - name: Install poetry
       shell: bash
       run: ${GITHUB_ACTION_PATH}/../lib/poetry-install.sh

--- a/release-poetry-package/action.yaml
+++ b/release-poetry-package/action.yaml
@@ -29,6 +29,12 @@ inputs:
     required: false
     description: User email to associate with release version bump commit.
     default: github-actions@example.com
+  s3-bucket-name:
+    required: false
+    description: S3 bucket name to cache node_modules to speed up dependency installation.
+  s3-bucket-region:
+    required: false
+    description: S3 bucket region to cache node_modules to speed up dependency installation.
 outputs:
   new-release-published:
     description: Whether a new release was published

--- a/release-poetry-package/action.yaml
+++ b/release-poetry-package/action.yaml
@@ -58,6 +58,8 @@ runs:
       run: echo '16.14.2' > .node-version
     - name: Setup tools
       uses: actions/setup-python@v5
+      with:
+        cache: "poetry"
     - name: Install poetry
       run: pip install poetry
       shell: bash

--- a/release-poetry-package/action.yaml
+++ b/release-poetry-package/action.yaml
@@ -29,12 +29,6 @@ inputs:
     required: false
     description: User email to associate with release version bump commit.
     default: github-actions@example.com
-  s3-bucket-name:
-    required: false
-    description: S3 bucket name to cache node_modules to speed up dependency installation.
-  s3-bucket-region:
-    required: false
-    description: S3 bucket region to cache node_modules to speed up dependency installation.
 outputs:
   new-release-published:
     description: Whether a new release was published
@@ -64,8 +58,6 @@ runs:
       run: echo '16.14.2' > .node-version
     - name: Setup tools
       uses: actions/setup-python@v5
-      with:
-        cache: "poetry"
     - name: Install poetry
       run: pip install poetry
       shell: bash

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -27,10 +27,11 @@ inputs:
     default: ""
   s3-bucket-name:
     required: false
-    description: S3 bucket name to cache node_modules to speed up dependency installation.
+    description: S3 bucket name to cache poetry venv
   s3-bucket-region:
     required: false
-    description: S3 bucket region to cache node_modules to speed up dependency installation.
+    description: S3 bucket region to cache poetry venv
+
 runs:
   using: composite
   steps:

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -41,6 +41,8 @@ runs:
         fetch-depth: 0
     - name: Setup python
       uses: actions/setup-python@v5
+      with:
+        cache: "poetry"
     # First we attempt to run a pip-based workflow if there is no poetry.lock
     - name: Install pip dependencies
       if: hashFiles('poetry.lock') == ''

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -25,7 +25,12 @@ inputs:
     required: false
     description: Coveralls repo token
     default: ""
-
+  s3-bucket-name:
+    required: false
+    description: S3 bucket name to cache node_modules to speed up dependency installation.
+  s3-bucket-region:
+    required: false
+    description: S3 bucket region to cache node_modules to speed up dependency installation.
 runs:
   using: composite
   steps:
@@ -41,8 +46,6 @@ runs:
         fetch-depth: 0
     - name: Setup python
       uses: actions/setup-python@v5
-      with:
-        cache: "poetry"
     # First we attempt to run a pip-based workflow if there is no poetry.lock
     - name: Install pip dependencies
       if: hashFiles('poetry.lock') == ''
@@ -70,10 +73,13 @@ runs:
       if: hashFiles('poetry.lock') != ''
       shell: bash
       run: pip install poetry
-    - name: Install poetry dependencies
-      if: hashFiles('poetry.lock') != ''
-      shell: bash
-      run: poetry install
+    - name: install poetry dependencies
+      if: success()
+      uses: actions-python/install-poetry-dependencies@v1
+      with:
+        github-token: ${{ inputs.github-token }}
+        s3-bucket-name: ${{ inputs.s3-bucket-name }}
+        s3-bucket-region: ${{ inputs.s3-bucket-region }}
     - name: Run setup script
       if: hashFiles('poetry.lock') != '' && inputs.setup-script != ''
       shell: bash


### PR DESCRIPTION
Trying to make use of setup-python action's [caching feature](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages) to cache poetry dependencies. CI workflows spend 80% of their time installing dependencies.