### PR TITLE
Run tests for pip based workflows when pytest is not installed

### DIFF
--- a/test/action.yaml
+++ b/test/action.yaml
@@ -61,7 +61,8 @@ runs:
         elif [[ -f setup.py ]]; then
           python setup.py test -- ${{ inputs.test-flags }}
         else
-          echo "No tests found"
+            pip install pytest
+            pytest ${{ inputs.test-flags }}
         fi
     # If we do have a poetry.lock, we use a poetry based workflow
     - name: install poetry


### PR DESCRIPTION
Before, we were skipping tests when pytest was not found in dependencies. Now we want to try and install it when it's not found in dependencies