### PR TITLE
Install pytest and run pytest in case of missing pytest dependency

### DIFF
--- a/test/action.yaml
+++ b/test/action.yaml
@@ -92,7 +92,9 @@ runs:
         if poetry show pytest &>/dev/null; then
           poetry run pytest ${{ inputs.test-flags }}
         else
-          echo "::warning::pytest not found in poetry.lock"
+          echo "::warning::pytest not found in poetry.lock, installing it and trying to run tests"
+          poetry add --group test pytest
+          poetry run pytest
         fi
     - name: Upload coverage
       if: inputs.upload-coverage != 'false'


### PR DESCRIPTION
If there are no pytest dependency in pyproject.toml, we will now try to install pytest and run the tests. If there are no tests in the project, pytest will fail.