### PR TITLE
feat: cache pre-commit in s3

### DIFF
--- a/lint/README.md
+++ b/lint/README.md
@@ -19,11 +19,13 @@ jobs:
 
 ## Inputs
 
-| parameter     | description                                                                                                       | required | default             |
-| ------------- | ----------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
-| checkout-repo | Perform checkout as first step of action                                                                          | `false`  | true                |
-| pypi-token    | PyPI token that can checkout the repository as well as create tags/releases against it. e.g. 'secrets.PYPI_TOKEN' | `false`  |                     |
-| github-token  | GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'                                        | `true`   | ${{ github.token }} |
+| name               | description                                                                        | required | default |
+| ------------------ | ---------------------------------------------------------------------------------- | -------- | ------- |
+| `checkout-repo`    | <p>Perform checkout as first step of action</p>                                    | `false`  | `true`  |
+| `github-token`     | <p>GitHub token that can checkout the repository. e.g. 'secrets.GITHUB_TOKEN'</p>  | `true`   | `""`    |
+| `release-notes`    | <p>Whether to generate release notes for the pull request</p>                      | `false`  | `true`  |
+| `s3-bucket-name`   | <p>S3 bucket name to cache node_modules to speed up dependency installation.</p>   | `false`  | `""`    |
+| `s3-bucket-region` | <p>S3 bucket region to cache node_modules to speed up dependency installation.</p> | `false`  | `""`    |
 
 ## Runs
 

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -13,6 +13,12 @@ inputs:
     required: false
     description: Whether to generate release notes for the pull request
     default: "true"
+  s3-bucket-name:
+    required: false
+    description: S3 bucket name to cache node_modules to speed up dependency installation.
+  s3-bucket-region:
+    required: false
+    description: S3 bucket region to cache node_modules to speed up dependency installation.
 
 runs:
   using: composite
@@ -29,3 +35,6 @@ runs:
         fetch-depth: 0
     - name: Run pre-commit
       uses: open-turo/action-pre-commit@v3
+      with:
+        s3-bucket-name: ${{ inputs.s3-bucket-name }}
+        s3-bucket-region: ${{ inputs.s3-bucket-region }}


### PR DESCRIPTION
This PR updates this repo to be able to cache pre-commit hooks in S3. It depends on open-turo/action-pre-commit#101