### PR TITLE
fix(release): use correct value for outputs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["github>open-turo/renovate-config#v1"]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,7 @@
 name: CI
 
 on:
-  pull_request:
-    branches: [main]
+  pull_request: {}
 
 jobs:
   lint:
@@ -12,10 +11,8 @@ jobs:
       - uses: open-turo/actions-gha/lint@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check release notes on pull_request
-        if: github.event_name == 'pull_request'
-        uses: open-turo/actions-release/lint-release-notes@v4
-
+          semantic-release-extra-plugins: |
+            @open-turo/semantic-release-config
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,6 @@ jobs:
       - uses: open-turo/actions-gha/lint@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -20,7 +19,6 @@ jobs:
       - uses: open-turo/actions-gha/test@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
   release:
     needs:
       - lint
@@ -31,3 +29,5 @@ jobs:
       - uses: open-turo/actions-gha/release@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-plugins: |
+            @open-turo/semantic-release-config

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,0 +1,25 @@
+name: Update dependencies
+concurrency: update-dependencies
+
+on:
+  schedule:
+    # Every day at midnight
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+  issue_comment:
+    types:
+      - edited
+  pull_request:
+    types:
+      - edited
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    name: Update dependencies
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: open-turo/action-renovate@v1
+        with:
+          github-token: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -21,13 +21,13 @@ inputs:
 outputs:
   new-release-published:
     description: Whether a new release was published
-    value: ${{ steps.release.outputs.new_release_published }}
+    value: ${{ steps.release.outputs.new-release-published }}
   new-release-version:
     description: Version of the new release
-    value: ${{ steps.release.outputs.new_release_version ||  steps.version.outputs.new_release_version }}
+    value: ${{ steps.release.outputs.new-release-version ||  steps.version.outputs.new-release-version }}
   new-release-major-version:
     description: Major version of the new release
-    value: ${{ steps.release.outputs.new_release_major_version }}
+    value: ${{ steps.release.outputs.new-release-major-version }}
 runs:
   using: composite
   steps:


### PR DESCRIPTION

**Description**


The outputs on release are referencing an incorrect value.

As part of this I also added renovatebot to this repo which was missing and many things were out of date.


**Changes**

* ci: add renovate bot and update ci
* fix(release): use correct value for outputs

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
