### PR TITLE
feat(release): use latest open-turo semantic release config

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -17,7 +17,7 @@ inputs:
     required: false
     description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
     default: |
-      @open-turo/semantic-release-config@^1.4.0
+      @open-turo/semantic-release-config
 outputs:
   new-release-published:
     description: Whether a new release was published


### PR DESCRIPTION

**Description**

I just realized this pythong repos were doing some things on releases that our latest config shouldn't do (like post messages in PRs with the released version). This PR updates the pinned version of the semantic release config to use the latest.

We had originally pinned it to 1.4.0 because of a bug in 2.0.0 that broke many things. All other repos are using the latest version.

**Changes**

- feat(release): use latest open-turo semantic release config

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
