### PR TITLE
feat(release): add working-directory input parameter

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -18,6 +18,10 @@ inputs:
     description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
     default: |
       @open-turo/semantic-release-config@^1.4.0
+  working-directory:
+    required: false
+    description: The working directory where the action should run
+    default: "."
 outputs:
   new-release-published:
     description: Whether a new release was published
@@ -37,9 +41,10 @@ runs:
       with:
         fetch-depth: 0
         token: ${{ inputs.github-token }}
-    - uses: open-turo/actions-release/semantic-release@v5
+    - uses: open-turo/actions-release/semantic-release@v5.0.4-rc1
       id: release
       with:
         github-token: ${{ inputs.github-token }}
         dry-run: ${{ inputs.dry-run }}
         extra-plugins: ${{ inputs.extra-plugins }}
+        working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
working-directory parameter allows to run the release action in a sub-directory, thus making easier to setup releases for monorepo projects.